### PR TITLE
refactor(ui): apply design polish to graph components

### DIFF
--- a/pro-dark-studio/src/components/graph/EdgePath.tsx
+++ b/pro-dark-studio/src/components/graph/EdgePath.tsx
@@ -1,5 +1,5 @@
-import { getCubicBezierPath } from "@/lib/geometry";
 import { clsx } from "clsx";
+import { X } from "lucide-react";
 
 type EdgePathProps = {
   id: string;
@@ -9,6 +9,7 @@ type EdgePathProps = {
   targetY: number;
   selected?: boolean;
   onSelect?: (id: string, shiftKey: boolean) => void;
+  onDelete?: (id: string) => void;
 };
 
 export default function EdgePath({
@@ -19,11 +20,15 @@ export default function EdgePath({
   targetY,
   selected,
   onSelect,
+  onDelete,
 }: EdgePathProps) {
-  const d = getCubicBezierPath(sourceX, sourceY, targetX, targetY);
+  // Simple orthogonal pathing
+  const midX = sourceX + (targetX - sourceX) / 2;
+  const d = `M ${sourceX},${sourceY} L ${midX},${sourceY} L ${midX},${targetY} L ${targetX},${targetY}`;
 
   return (
     <g
+      className="group"
       onMouseDown={(e) => {
         e.stopPropagation();
         onSelect?.(id, e.shiftKey);
@@ -32,36 +37,35 @@ export default function EdgePath({
       <path
         d={d}
         className={clsx(
-          "fill-none stroke-slate-500 hover:stroke-slate-300",
-          selected && "stroke-emerald-400/70"
+          "fill-none stroke-subtle transition-all duration-fast",
+          "group-hover:stroke-muted",
+          selected && "stroke-info/60"
         )}
-        strokeWidth={2}
+        strokeWidth={1.5}
       />
-      {/* Hit area */}
       <path d={d} className="stroke-transparent fill-none" strokeWidth={16} />
-      {/* Arrowhead */}
-      <defs>
-        <marker
-          id="arrowhead"
-          viewBox="0 0 10 10"
-          refX="9"
-          refY="5"
-          markerWidth="6"
-          markerHeight="6"
-          orient="auto-start-reverse"
-        >
-          <path d="M 0 0 L 10 5 L 0 10 z" className={clsx(
-            "fill-slate-500",
-            selected && "fill-emerald-400/70"
-          )} />
-        </marker>
-      </defs>
+
       <path
         d={d}
         stroke="transparent"
         fill="none"
-        markerEnd="url(#arrowhead)"
+        markerEnd={`url(#arrowhead-${selected ? 'selected' : 'default'})`}
       />
+
+      <foreignObject
+        x={midX - 12}
+        y={sourceY + (targetY - sourceY) / 2 - 12}
+        width="24"
+        height="24"
+        className="opacity-0 group-hover:opacity-100 transition-opacity duration-fast pointer-events-auto"
+      >
+        <button
+            className="p-1 rounded-full bg-panel-2 hover:bg-danger text-muted hover:text-white"
+            onClick={() => onDelete?.(id)}
+        >
+            <X className="size-4" />
+        </button>
+      </foreignObject>
     </g>
   );
 }

--- a/pro-dark-studio/src/components/graph/GraphCanvas.tsx
+++ b/pro-dark-studio/src/components/graph/GraphCanvas.tsx
@@ -30,6 +30,7 @@ export default function GraphCanvas() {
     tempEdge,
     moveNode,
     select,
+    deleteSelection,
     beginConnect,
     endConnect,
     updateMousePosition,
@@ -107,6 +108,13 @@ export default function GraphCanvas() {
     select({ edges: Array.from(newSelection), nodes: [] });
   };
 
+  const handleEdgeDelete = (edgeId: string) => {
+    select({ edges: [edgeId], nodes: [] });
+    // This is a bit of a hack. The deleteSelection action will delete the selected edge.
+    // A better way would be a dedicated deleteEdge action.
+    setTimeout(() => deleteSelection(), 0);
+  };
+
   const getNodePortPosition = (node: any, side: "in" | "out") => {
     const y = node.y + NODE_HEIGHT / 2;
     const x = side === 'in' ? node.x : node.x + NODE_WIDTH;
@@ -137,6 +145,14 @@ export default function GraphCanvas() {
       />
 
       <svg className="absolute inset-0 w-full h-full pointer-events-none">
+        <defs>
+            <marker id="arrowhead-default" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 5 L 0 10 z" className="fill-subtle" />
+            </marker>
+            <marker id="arrowhead-selected" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 5 L 0 10 z" className="fill-info/60" />
+            </marker>
+        </defs>
         <g style={{ transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})` }}>
           {edges.map((e) => {
             const fromNode = nodes.find((n) => n.id === e.from);
@@ -156,6 +172,7 @@ export default function GraphCanvas() {
                 targetY={target.y}
                 selected={selection.edges.has(e.id)}
                 onSelect={handleEdgeSelect}
+                onDelete={handleEdgeDelete}
               />
             );
           })}
@@ -208,6 +225,7 @@ export default function GraphCanvas() {
             ref={n.ref}
             kind={n.kind}
             title={n.title}
+            subtitle={n.ref}
             x={n.x}
             y={n.y}
             scale={transform.scale}

--- a/pro-dark-studio/src/components/graph/NodeCard.tsx
+++ b/pro-dark-studio/src/components/graph/NodeCard.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { clsx } from "clsx";
 import { snapToGrid } from "@/lib/geometry";
 import { NodeKind } from "@/types/core";
@@ -12,6 +15,7 @@ type Props = {
   y: number;
   scale: number;
   title: string;
+  subtitle: string;
   selected?: boolean;
   onMove: (id: string, x: number, y: number) => void;
   onPortDragStart: (id: string, side: "in" | "out", e: React.MouseEvent) => void;
@@ -19,20 +23,26 @@ type Props = {
 };
 
 const nodeInfoByKind = {
-  trigger: { color: "bg-node-trigger", icon: Zap },
-  condition: { color: "bg-node-condition", icon: GitBranch },
-  action: { color: "bg-node-action", icon: Play },
-  end: { color: "bg-node-end", icon: Flag },
+  trigger: { color: "node-trigger", icon: Zap },
+  condition: { color: "node-condition", icon: GitBranch },
+  action: { color: "node-action", icon: Play },
+  end: { color: "node-end", icon: Flag },
 };
 
 export default function NodeCard(p: Props) {
-  const style = { transform: `translate(${p.x}px, ${p.y}px)` };
+  const [isDragging, setIsDragging] = useState(false);
   const info = nodeInfoByKind[p.kind];
+  const style = {
+    transform: `translate(${p.x}px, ${p.y}px) scale(${isDragging ? 1.02 : 1})`,
+    minWidth: '220px',
+    minHeight: '92px',
+  };
 
   const onMouseDown = (e: React.MouseEvent) => {
     if ((e.target as HTMLElement).closest("[data-port]")) return;
 
     p.onSelect(p.id, e.shiftKey);
+    setIsDragging(true);
 
     const start = { x: e.clientX, y: e.clientY, ox: p.x, oy: p.y };
     const onMove = (ev: MouseEvent) => {
@@ -41,6 +51,7 @@ export default function NodeCard(p: Props) {
       p.onMove(p.id, nx, ny);
     };
     const onUp = () => {
+      setIsDragging(false);
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
@@ -53,31 +64,25 @@ export default function NodeCard(p: Props) {
       data-node
       data-node-id={p.id}
       className={clsx(
-        "absolute select-none rounded-xl border border-stroke w-56 group",
-        "bg-panel shadow-md transition-shadow duration-200",
-        p.selected && "ring-2 ring-interactive shadow-glow-sm"
+        "absolute select-none rounded-card bg-panel shadow-1 border border-stroke transition-all duration-fast group",
+        "hover:shadow-2 hover:border-stroke/80",
+        p.selected && `ring-2 ring-offset-2 ring-offset-panel ring-${info.color}/60`,
+        isDragging && "shadow-2 z-10"
       )}
       style={style}
       onMouseDown={onMouseDown}
     >
-      <div
-        className={clsx(
-          "h-8 rounded-t-xl px-3 flex items-center gap-2",
-          info.color
+      <div className={clsx("h-1.5 rounded-t-card", `bg-${info.color}`)} />
+      <div className="p-3">
+        <div className="flex items-center gap-3">
+            <info.icon className={clsx("size-5", `text-${info.color}`)} />
+            <span className="text-sm font-semibold">{p.title}</span>
+        </div>
+        {p.subtitle && (
+            <div className="mt-2 text-xs text-subtle pl-8">
+                {p.subtitle}
+            </div>
         )}
-      >
-        <info.icon className="size-4 text-white/80" />
-        <span className="text-sm font-semibold text-white">{p.title}</span>
-      </div>
-      <div className="p-3 text-xs text-muted space-y-2">
-        <div>
-          <div className="font-bold uppercase text-muted/50 text-[10px]">ID</div>
-          <div className="font-mono">{p.id}</div>
-        </div>
-        <div>
-          <div className="font-bold uppercase text-muted/50 text-[10px]">Ref</div>
-          <div className="font-mono">{p.ref}</div>
-        </div>
       </div>
 
       <PortHandle


### PR DESCRIPTION
This commit implements the third step of the design polish pass: refining the graph-specific components to use the new design tokens and match the new visual style.

Key changes include:
- `NodeCard.tsx` has been redesigned with a colored header strip, improved layout, and subtle hover/selection effects.
- `EdgePath.tsx` now renders orthogonal paths and includes a delete handle on hover.
- The visual style of ports and edges has been updated.